### PR TITLE
docs: 更新采样准确率API文档中的字段名称

### DIFF
--- a/src/latest/sample/get-sampling-accuracy.md
+++ b/src/latest/sample/get-sampling-accuracy.md
@@ -29,8 +29,8 @@ api:
     "code": 2000,
     "message": "Success",
     "data": {
-      "manualAnnotationFrames": 50,
-      "autoAnnotationFrames": 30
+      "frameAccuracyRate": 50.2,
+      "accuracyRate": 30
     },
     "date": "2025-03-13 20:00:00",
     "requestId": "7610aa38c0fc409d98c827a879d9cae5",


### PR DESCRIPTION
将`manualAnnotationFrames`和`autoAnnotationFrames`字段更新为`frameAccuracyRate`和`accuracyRate`，以更准确地反映数据含义