### PR TITLE
docs: 更新文档中的字段名称

### DIFF
--- a/src/latest/sample/get-sampling-accuracy.md
+++ b/src/latest/sample/get-sampling-accuracy.md
@@ -30,7 +30,7 @@ api:
     "message": "Success",
     "data": {
       "frameAccuracyRate": 50.2,
-      "accuracyRate": 30
+      "instanceAccuracyRate": 30
     },
     "date": "2025-03-13 20:00:00",
     "requestId": "7610aa38c0fc409d98c827a879d9cae5",


### PR DESCRIPTION
将文档中的 `accuracyRate` 字段名称更新为 `instanceAccuracyRate`，以保持与代码实现的一致性