### PR TITLE
docs: 更新API文档示例以包含更多错误响应

### DIFF
--- a/src/latest/sample/create-sampling.md
+++ b/src/latest/sample/create-sampling.md
@@ -62,6 +62,38 @@ api:
     "date": "2025-03-13 20:00:00",
     "requestId": "7610aa38c0fc409d98c827a879d9cae5",
     "success": true
+  },
+  "53003": {
+    "code": 53003,
+    "data": null,
+    "message": "Annotation request has not exists.",
+    "date": "2025-03-13 20:00:00",
+    "requestId": "864b70706a7349ea83e177a49800464f",
+    "success": false
+  },
+  "55005": {
+    "code": 55005,
+    "data": null,
+    "message": "Pool not found",
+    "date": "2025-03-13 20:00:00",
+    "requestId": "864b70706a7349ea83e177a49800464f",
+    "success": false
+  },
+  "57008": {
+    "code": 57008,
+    "data": null,
+    "message": "Sampling Package not found.",
+    "date": "2025-03-13 20:00:00",
+    "requestId": "864b70706a7349ea83e177a49800464f",
+    "success": false
+  },
+  "5606": {
+    "code": 5606,
+    "data": null,
+    "message": "The remaining tasks in the current working pool are 0 and cannot be assigned",
+    "date": "2025-03-13 20:00:00",
+    "requestId": "864b70706a7349ea83e177a49800464f",
+    "success": false
   }
 }
 ```

--- a/src/latest/sample/get-sampling-accuracy.md
+++ b/src/latest/sample/get-sampling-accuracy.md
@@ -35,6 +35,14 @@ api:
     "date": "2025-03-13 20:00:00",
     "requestId": "7610aa38c0fc409d98c827a879d9cae5",
     "success": true
+  },
+  "57008": {
+    "code": 57008,
+    "data": null,
+    "message": "Sampling Package not found.",
+    "date": "2025-03-13 20:00:00",
+    "requestId": "864b70706a7349ea83e177a49800464f",
+    "success": false
   }
 }
 ```


### PR DESCRIPTION
在`get-sampling-accuracy.md`和`create-sampling.md`中添加了新的错误响应示例，以更全面地覆盖API可能返回的错误情况。这些更新有助于开发者更好地理解和处理API调用中的异常情况。