### PR TITLE
docs: 更新采样创建文档中的枚举值顺序

### DIFF
--- a/src/latest/sample/create-sampling.md
+++ b/src/latest/sample/create-sampling.md
@@ -26,12 +26,12 @@ api:
     "default": "1",
     "required": false,
     "enum": {
-      "1": "random continuity",
-      "2": "positive",
-      "3": "reversed",
-      "4": "system random",
-      "5": "custom",
-      "6": "sequencelength"
+      "random continuity": "1",
+      "positive": "2",
+      "reversed": "3",
+      "system random": "4",
+      "custom": "5",
+      "sequencelength": "6"
     }
   },
   "interceptionFrame": {


### PR DESCRIPTION
将`create-sampling.md`中的枚举值顺序从“键: 值”改为“值: 键”，以提高文档的可读性和一致性