### PR TITLE
docs: 在API文档中添加samplingRatio字段

### DIFF
--- a/src/latest/sample/create-sampling.md
+++ b/src/latest/sample/create-sampling.md
@@ -20,6 +20,11 @@ api:
     "description": "Rosetta Pool Name",
     "default": "a3f8b6e4-9c1d-4d8a-93b2-7f7e8f3a1d5e-SamplingPool"
   },
+  "samplingRatio": {
+    "type": "number",
+    "description": "Sampling ratio",
+    "default": "1.0"
+  },
   "interceptionMode": {
     "type": "number",
     "description": "Interception method value, Please see the enumeration values defined below. They are not intercepted by default",


### PR DESCRIPTION
在create-sampling.md文档中新增samplingRatio字段，用于描述采样比例，默认值为1.0